### PR TITLE
fix: prevent unnecessarily setting search value state to undefined

### DIFF
--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -50,7 +50,7 @@ const SearchBar = ({ big }: SearchProps) => {
       setNextUserState({ numOfSearches: Number(userState.numOfSearches) + 1 })
     }
 
-    if (query !== (searchValue && undefined)) {
+    if (query !== undefined && query !== searchValue) {
       setSearchValue(query)
     }
   }, [query])


### PR DESCRIPTION
In case of query being undefined and search value being an empty string
we'd be calling `setSearchValue` with `undefined` because `('' && undefined)`
evaluates to an empty string that would be unequal to undefined.

This leads to an extra render and a warning in the Header test:
"A component is changing a controlled input to be uncontrolled.
This is likely caused by the value changing from a defined to undefined,
which should not happen. Decide between using a controlled or uncontrolled
input element for the lifetime of the component."