### PR TITLE
fix: improve code handling search input change

### DIFF
--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -148,8 +148,7 @@ const SearchBar = ({ big }: SearchProps) => {
   function handleOnChange(value: string) {
     setSearchValue(value)
 
-    const trimmedValue = value.trim()
-    if (trimmedValue) {
+    if (value.trim()) {
       setSearchSuggestedWords(true)
       setIsSuggestionOpen(true)
     }

--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -145,10 +145,14 @@ const SearchBar = ({ big }: SearchProps) => {
     search(word)
   }
 
-  function handleOnChange(el) {
-    setSearchValue(el)
-    setSearchSuggestedWords(true)
-    searchValue !== ('' || undefined) && setIsSuggestionOpen(true)
+  function handleOnChange(value: string) {
+    setSearchValue(value)
+
+    const trimmedValue = value.trim()
+    if (trimmedValue) {
+      setSearchSuggestedWords(true)
+      setIsSuggestionOpen(true)
+    }
   }
 
   return (


### PR DESCRIPTION
* Make sure to use the actual input value from the event instead of
  the state because the state will be updated asynchronously.

* Don't activate suggestion functionality if we only have white space
  as input. Trim the string before checking.

Note:
The old code `('' || undefined)` will always result in `undefined`.
Seems as if the intended code is `(searchValue !== '' || searchValue !== undefined) && setIsSuggestionOpen(true)`
but probably `searchValue && setIsSuggestionOpen(true)` would be sufficient
because other falsy values such as `null` and `0` are not to be expected.