### PR TITLE
fix: Add allow any headers on local host

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,5 +2,5 @@
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 # Use the below endpoint if you have access to ElliotForWater Api staging project
-NEXT_PUBLIC_API_URL=https://localhost:5001/api
+NEXT_PUBLIC_API_URL=http://localhost:5001/api
 

--- a/__mocks__/mockapiServer.js
+++ b/__mocks__/mockapiServer.js
@@ -1,12 +1,9 @@
 const jsonServer = require('json-server')
 const server = jsonServer.create()
 const router = jsonServer.router('db.json')
+const middlewares = jsonServer.defaults()
 
-server.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', 'http://localhost:3000')
-  res.header('Access-Control-Allow-Headers', '*')
-  next()
-})
+server.use(middlewares)
 
 server.use('/api/searchresults', router)
 server.listen(5001, () => {

--- a/__mocks__/mockapiServer.js
+++ b/__mocks__/mockapiServer.js
@@ -5,7 +5,8 @@ const middlewares = jsonServer.defaults({ noCors: true })
 
 server.use(middlewares)
 
-server.use((res, next) => {
+server.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', 'http://localhost:3000')
   res.header('Access-Control-Allow-Headers', '*')
   next()
 })

--- a/__mocks__/mockapiServer.js
+++ b/__mocks__/mockapiServer.js
@@ -5,6 +5,11 @@ const middlewares = jsonServer.defaults({ noCors: true })
 
 server.use(middlewares)
 
+server.use((res, next) => {
+  res.header('Access-Control-Allow-Headers', '*')
+  next()
+})
+
 server.use('/api/searchresults', router)
 server.listen(5001, () => {
   console.log('Mock api server listening at localhost:5001')

--- a/__mocks__/mockapiServer.js
+++ b/__mocks__/mockapiServer.js
@@ -1,9 +1,6 @@
 const jsonServer = require('json-server')
 const server = jsonServer.create()
 const router = jsonServer.router('db.json')
-const middlewares = jsonServer.defaults({ noCors: true })
-
-server.use(middlewares)
 
 server.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', 'http://localhost:3000')


### PR DESCRIPTION
Given I am a developer running the UI and Mock API
When I make a search in the UI
Then I should see results returned