### PR TITLE
fix: adjust input type handling radio or checkbox

### DIFF
--- a/components/Forms/Inputs/Inputs.tsx
+++ b/components/Forms/Inputs/Inputs.tsx
@@ -11,7 +11,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 export function Input({ name, type, register, rules = {}, errors = {}, customClassname, ...rest }: InputProps) {
   return (
-    <div className={type === ('checkbox' || 'radiobox') ? styles.inputWrapInline : styles.inputWrap}>
+    <div className={type === 'checkbox' || type === 'radiobox' ? styles.inputWrapInline : styles.inputWrap}>
       <input
         className={classnames({ [styles.inputError]: errors[name] }, customClassname, styles.input)}
         name={name}


### PR DESCRIPTION
Fix input component type handling.

Previous code would have always result in `radiobox`. 
So it wouldn't have apply `inputWrapInline` style for `checkbox` type 
