### PR TITLE
fix: handle undefined searchValue 

### DIFF
--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -133,7 +133,7 @@ const SearchBar = ({ big }: SearchProps) => {
   function search(word?: string, event?) {
     setNextUserState({ numOfSearches: Number(userState.numOfSearches) + 1 })
 
-    if ((word && word !== '') || searchValue !== '') {
+    if ((word && word !== '') || !!searchValue) {
       const queryNoSpace = queryNoWitheSpace(word || searchValue)
       router.push(`search?query=${queryNoSpace}&type=${typeValue}`)
       resetDropdown(event)


### PR DESCRIPTION
Do not proceed with search functionality if search value is undefined.

Current behavior: 
On search input, when user click search button without any value on it, an error is arise

New behavior:
On search input, when user click search button or press enter without any value in it, no error are arise and search function just return without changing the router