### PR TITLE
fix: hide gmail tab on mobile

### DIFF
--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -34,6 +34,8 @@ export default function ButtonAddToBrowser() {
     }
   }, [])
 
+  console.log('ciao', browserName, browserName === '')
+
   return (
     <div className='hideSmallScreen'>
       {browserName !== '' && (

--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -34,8 +34,6 @@ export default function ButtonAddToBrowser() {
     }
   }, [])
 
-  console.log('ciao', browserName, browserName === '')
-
   return (
     <div className='hideSmallScreen'>
       {browserName !== '' && (

--- a/components/TabItem/TabItem.module.css
+++ b/components/TabItem/TabItem.module.css
@@ -55,6 +55,10 @@
   background-color: #eee;
 }
 
+.hiddenMobile {
+  display: none;
+}
+
 .linkIcon {
   padding-right: 12px;
   font-size: 1.3em;
@@ -71,6 +75,10 @@
 }
 
 @media (min-width: 768px) {
+  .hiddenMobile {
+    display: inline;
+  }
+
   .tab {
     padding-right: 12px;
   }

--- a/components/TabItem/TabItem.module.css
+++ b/components/TabItem/TabItem.module.css
@@ -4,6 +4,10 @@
   cursor: pointer;
 }
 
+.tabWithDropdown {
+  position: relative;
+}
+
 .title {
   color: var(--textColor);
   padding: 0 5px 0 5px;
@@ -40,7 +44,7 @@
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 4px;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-  right: 15px;
+  right: 6px;
 }
 
 .dropdown li a {
@@ -53,10 +57,6 @@
 .dropdown li a:hover {
   text-decoration: none;
   background-color: #eee;
-}
-
-.hiddenMobile {
-  display: none;
 }
 
 .linkIcon {
@@ -74,11 +74,13 @@
   color: #6442a4;
 }
 
-@media (min-width: 768px) {
-  .hiddenMobile {
-    display: inline;
+@media (min-width: 500px) {
+  .dropdown {
+    left: 0;
   }
+}
 
+@media (min-width: 768px) {
   .tab {
     padding-right: 12px;
   }

--- a/components/TabItem/TabItem.tsx
+++ b/components/TabItem/TabItem.tsx
@@ -1,5 +1,7 @@
 import React, { FC, ReactElement, useState, useEffect, useRef } from 'react'
 import classnames from 'classnames'
+import { isMobile } from 'react-device-detect'
+import { useMediaQuery } from '../../hooks/useMediaQuery'
 import styles from './TabItem.module.css'
 
 interface tabObjectProp {
@@ -21,6 +23,7 @@ const TabsMenu: FC<tabItemProp> = ({ title, icon, onItemClicked, isActive, links
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false)
   const iconMenuEl = useRef(null)
   const menuEl = useRef(null)
+  const isBreakpoint = useMediaQuery(768)
 
   useEffect(() => {
     function handleClickOutside(event) {
@@ -39,7 +42,7 @@ const TabsMenu: FC<tabItemProp> = ({ title, icon, onItemClicked, isActive, links
 
   return (
     <div
-      className={classnames(styles.tab, { [styles.active]: isActive })}
+      className={classnames(styles.tab, { [styles.active]: isActive, [styles.tabWithDropdown]: !!links })}
       onClick={() => {
         if (links) {
           setIsDropdownOpen((prev) => !prev)
@@ -55,14 +58,18 @@ const TabsMenu: FC<tabItemProp> = ({ title, icon, onItemClicked, isActive, links
       {isDropdownOpen && (
         <ul className={styles.dropdown} ref={menuEl}>
           {links &&
-            links.map((item: { id: string; label: string; link: string; icon: ReactElement }) => (
-              <li key={item.label} className={classnames({ [styles.hiddenMobile]: item.id === 'gmail' })}>
-                <a href={`${item.link}${query}`} target='_blank'>
-                  <span className={classnames(styles.linkIcon, styles[item.id])}>{item.icon}</span>
-                  {item.label}
-                </a>
-              </li>
-            ))}
+            links.map((item: { id: string; label: string; link: string; icon: ReactElement }) => {
+              if (isMobile && item.id === 'gmail' && isBreakpoint) return
+
+              return (
+                <li key={item.label}>
+                  <a href={`${item.link}${query}`} target='_blank'>
+                    <span className={classnames(styles.linkIcon, styles[item.id])}>{item.icon}</span>
+                    {item.label}
+                  </a>
+                </li>
+              )
+            })}
         </ul>
       )}
     </div>

--- a/components/TabItem/TabItem.tsx
+++ b/components/TabItem/TabItem.tsx
@@ -56,7 +56,7 @@ const TabsMenu: FC<tabItemProp> = ({ title, icon, onItemClicked, isActive, links
         <ul className={styles.dropdown} ref={menuEl}>
           {links &&
             links.map((item: { id: string; label: string; link: string; icon: ReactElement }) => (
-              <li key={item.label}>
+              <li key={item.label} className={classnames({ [styles.hiddenMobile]: item.id === 'gmail' })}>
                 <a href={`${item.link}${query}`} target='_blank'>
                   <span className={classnames(styles.linkIcon, styles[item.id])}>{item.icon}</span>
                   {item.label}

--- a/components/TabsMenu/TabsMenu.test.tsx
+++ b/components/TabsMenu/TabsMenu.test.tsx
@@ -1,8 +1,12 @@
+import mockMediaQuery from '../../__mocks__/matchMedia'
+
 import React, { useState } from 'react'
 import { mount } from 'enzyme'
 import { render, fireEvent } from '@testing-library/react'
 import TabsMenu from './TabsMenu'
 import TabItem from '../TabItem/TabItem'
+
+mockMediaQuery()
 
 function Content({ children }) {
   return children


### PR DESCRIPTION
On search page, Option to search in Gmail account should be visible just on desktop because it doesn't work on mobile.

**Before**:
On search page > in the navigation tabs > click on tab "More" > open dropdown
I can see the gmail option both on mobile and desktop

**After**:
On search page > in the navigation tabs > click on tab "More" > open dropdown
I can see the gmail option just on desktop
