### PR TITLE
Fix add to browser button

### DIFF
--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -41,7 +41,7 @@ export default function ButtonAddToBrowser() {
         setBrowserName('firefox')
       }
     }
-  }, [browserName])
+  }, [])
 
   return (
     <div className='hideSmallScreen'>

--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -21,12 +21,19 @@ export default function ButtonAddToBrowser() {
 
   useEffect(() => {
     if (isBrowser && isChrome) {
-      setBrowserName('chrome')
       /* eslint-disable-next-line no-undef */
-      chrome.runtime.sendMessage(config.CHROME_EXTENSION_ID, {
-        action: 'id',
-        value: config.CHROME_EXTENSION_ID,
-      })
+      chrome.runtime.sendMessage(
+        config.CHROME_EXTENSION_ID,
+        {
+          action: 'id',
+          value: config.CHROME_EXTENSION_ID,
+        },
+        function (response) {
+          if (!response) {
+            setBrowserName('chrome')
+          }
+        }
+      )
     }
 
     if (isFirefox) {

--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -30,16 +30,18 @@ export default function ButtonAddToBrowser() {
         },
         function (response) {
           if (!response) {
-            setBrowserName('chrome')
+            return setBrowserName('chrome')
           }
         }
       )
     }
 
     if (isFirefox) {
-      setBrowserName('firefox')
+      if (!window.extensionInterface) {
+        setBrowserName('firefox')
+      }
     }
-  }, [])
+  }, [browserName])
 
   return (
     <div className='hideSmallScreen'>

--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -4,6 +4,8 @@ import useTranslation from 'next-translate/useTranslation'
 import config from '../../appConfig'
 import { isBrowser, isChrome, isFirefox } from 'react-device-detect'
 
+declare const window: any
+
 const buttonInfo = {
   chrome: {
     url: config.CHROME_EXTENSION_URL,


### PR DESCRIPTION
Add to "Chrome and Firefox" button now works accordingly to the installed browser extension.
Before the button was always shown there.