### PR TITLE
fix grab cookies value in UserContext insetad of Layout

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect } from 'react'
+import React, { FC, useContext } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import Header from '../Header/Header'
@@ -7,13 +7,6 @@ import Footer from '../Footer/Footer'
 import styles from './Layout.module.css'
 import Modal from '../Modal/Modal'
 import { UserContext } from '../../context/UserContext'
-import Cookies from 'js-cookie'
-import {
-  COOKIE_NAME_SEARCH_COUNT,
-  COOKIE_NAME_ADULT_FILTER,
-  COOKIE_NAME_LANGUAGE,
-  COOKIE_NAME_NEW_TAB,
-} from '../../helpers/_cookies'
 interface LayoutProps {
   fluid?: boolean
   pageTitle: string
@@ -24,21 +17,7 @@ interface LayoutProps {
 export const Layout: FC<LayoutProps> = ({ children, fluid, pageTitle, pageDescription, isHome }) => {
   const router = useRouter()
   const { query } = router.query
-  const { userState, setNextUserState } = useContext(UserContext)
-
-  useEffect(() => {
-    const searchesFromCookies = Cookies.get(COOKIE_NAME_SEARCH_COUNT)
-    const languageFromCookies = Cookies.get(COOKIE_NAME_LANGUAGE)
-    const filterFromCookies = Cookies.get(COOKIE_NAME_ADULT_FILTER)
-    const newTabFromCookies = Cookies.get(COOKIE_NAME_NEW_TAB)
-
-    setNextUserState({
-      numOfSearches: Number(searchesFromCookies) || 0,
-      language: Number(languageFromCookies) || 1,
-      adultContentFilter: Number(filterFromCookies) || 1,
-      openInNewTab: newTabFromCookies !== 'false',
-    })
-  }, [])
+  const { userState } = useContext(UserContext)
 
   return (
     <div className={userState.isModalOpen ? styles.noOverflow : styles.overflow}>

--- a/context/UserContext.tsx
+++ b/context/UserContext.tsx
@@ -1,4 +1,16 @@
 import React from 'react'
+import {
+  COOKIE_NAME_LANGUAGE,
+  COOKIE_NAME_ADULT_FILTER,
+  COOKIE_NAME_NEW_TAB,
+  COOKIE_NAME_SEARCH_COUNT,
+} from '../helpers/_cookies'
+import Cookies from 'js-cookie'
+
+const searchesFromCookies = Cookies.get(COOKIE_NAME_SEARCH_COUNT)
+const languageFromCookies = Cookies.get(COOKIE_NAME_LANGUAGE)
+const filterFromCookies = Cookies.get(COOKIE_NAME_ADULT_FILTER)
+const newTabFromCookies = Cookies.get(COOKIE_NAME_NEW_TAB)
 interface userState {
   numOfSearches: number
   language: number
@@ -12,10 +24,10 @@ export interface userContextProps {
 }
 
 export const USER_STATE_DEFAULT = {
-  numOfSearches: 0,
-  language: 1, // English
-  adultContentFilter: 1, // Moderate
-  openInNewTab: false,
+  numOfSearches: Number(searchesFromCookies) || 0,
+  language: Number(languageFromCookies) || 1, // English
+  adultContentFilter: Number(filterFromCookies) || 1, // Moderate
+  openInNewTab: newTabFromCookies !== 'false' || false,
   isModalOpen: false,
 }
 


### PR DESCRIPTION
Before we were setting default user context value in UserContext.tsx and than getting cookies value in Layout.tsx and update the UserContext.
This created problems, when part of the apps that are using cookies, run before Layout.tsx is rendered.

Now we grab the cookies value in UserContext.tsx and add the value to the User Context directly there. 
If cookies is not there, we have the default value.

@qweqsbrako this should hopefully fix our extension counter issue
tagging also @ConradParker since we talked recently about this code improvement