### PR TITLE
fix: set cookie init value to user state

### DIFF
--- a/components/Forms/Settings/SettingsForm.tsx
+++ b/components/Forms/Settings/SettingsForm.tsx
@@ -16,12 +16,13 @@ type InputsProp = {
 const SettingsForm = ({ callbackCloseSettings }) => {
   const { t } = useTranslation()
   const { userState, setNextUserState } = useContext(UserContext)
+  const { language, adultContentFilter, openInNewTab } = userState
 
   const methods = useForm<InputsProp>({
     defaultValues: {
-      language: userState.language,
-      adultContentFilter: userState.adultContentFilter,
-      openInNewTab: userState.openInNewTab,
+      language,
+      adultContentFilter,
+      openInNewTab,
     },
   })
   const { handleSubmit, register } = methods
@@ -72,7 +73,13 @@ const SettingsForm = ({ callbackCloseSettings }) => {
             </div>
 
             <div className='control-group'>
-              <Input id='openInNewTab' name='openInNewTab' className={styles.checkbox} type='checkbox' register={register} />
+              <Input
+                id='openInNewTab'
+                name='openInNewTab'
+                className={styles.checkbox}
+                type='checkbox'
+                register={register}
+              />
               <label className={styles.checkboxLabel} htmlFor='openInNewTab'>
                 {t('common:settings.new_tab')}
               </label>

--- a/hooks/useUserContext.tsx
+++ b/hooks/useUserContext.tsx
@@ -26,7 +26,6 @@ export const useUserContext = (): userContextProps => {
       }
 
       for (const key in nextState) {
-        // if (cookiesName.hasOwnProperty(key)) {
         if (Object.getOwnPropertyDescriptor(cookiesName, key)) {
           Cookies.set(cookiesName[key], newState[key])
         }

--- a/hooks/useUserContext.tsx
+++ b/hooks/useUserContext.tsx
@@ -26,7 +26,10 @@ export const useUserContext = (): userContextProps => {
       }
 
       for (const key in nextState) {
-        Cookies.set(cookiesName[key], newState[key])
+        // if (cookiesName.hasOwnProperty(key)) {
+        if (Object.getOwnPropertyDescriptor(cookiesName, key)) {
+          Cookies.set(cookiesName[key], newState[key])
+        }
       }
 
       return newState

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -35,7 +35,11 @@ const setCookiesToState = (userState) => {
       if (!Cookies.get(cookiesName[key])) {
         Cookies.set(cookiesName[key], userState[key])
       } else {
-        userState[key] = Cookies.get(cookiesName[key])
+        userState.numOfSearches = Number(Cookies.get(cookiesName.numOfSearches))
+        userState.language = Number(Cookies.get(cookiesName.language))
+        userState.adultContentFilter = Number(Cookies.get(cookiesName.adultContentFilter))
+        userState.openInNewTab = Cookies.get(cookiesName.openInNewTab) !== 'false'
+
         Cookies.set(cookiesName[key], Cookies.get(cookiesName[key]))
       }
     }


### PR DESCRIPTION
Cookies initial value were set to user state as string.
Now they are set with their correct type: numbers or boolean.

Also, in useUserContext we now set cookies when new user state is update, just if the value exist in the cookies object.
