### PR TITLE
core: Add codeowners file 

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,6 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @ElliotForWater/elliotforwater-core-devs
+


### PR DESCRIPTION
Codeowners file should automatically assign PRs to elliotforwater-core-devs team

From Github documentation:
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.