### PR TITLE
fix: add check if chrome runtime is defined

### DIFF
--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -23,19 +23,24 @@ export default function ButtonAddToBrowser() {
 
   useEffect(() => {
     if (isBrowser && isChrome) {
-      /* eslint-disable-next-line no-undef */
-      chrome.runtime.sendMessage(
-        config.CHROME_EXTENSION_ID,
-        {
-          action: 'id',
-          value: config.CHROME_EXTENSION_ID,
-        },
-        function (response) {
-          if (!response) {
-            return setBrowserName('chrome')
+      /* eslint-disable no-undef */
+      if (chrome.runtime) {
+        chrome.runtime.sendMessage(
+          /* eslint-enable no-undef */
+          config.CHROME_EXTENSION_ID,
+          {
+            action: 'id',
+            value: config.CHROME_EXTENSION_ID,
+          },
+          function (response) {
+            if (!response) {
+              return setBrowserName('chrome')
+            }
           }
-        }
-      )
+        )
+      }
+    } else {
+      return setBrowserName('chrome')
     }
 
     if (isFirefox) {


### PR DESCRIPTION
## Description
It conditionally check if we have chrome runtime environment running.
if so, connect to the extension, if not, show add to chrome button. 

#### Impacted Areas in Application
Anywhere where we use Add To Chrome button

#### Steps to Test or Reproduce
Run app in development mode and open it in chrome without the extension enable.
You should not see any error and be able to use the app propely.

------------------------------------------------
## PR Checklist:

- [ ] My code follows the style guidelines of this project and I have double check my own code
- [ ] I have made corresponding changes to the documentation, if any
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run test` and be sure all test pass
- [ ] I have run `npm run build:dev` and be sure no error blovk the build
- [ ] I have test locally that everything run as expected
- [ ] I have properly fill in the PR template
- [ ] I have ask for reviews
