### PR TITLE
fix: update url if we have just a q param from search url

### DIFF
--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -429,8 +429,22 @@ interface resultsObj {
 
 // cannot use getServerSideProps yet: https://github.com/vercel/next.js/discussions/17269
 SearchPage.getInitialProps = async ({ req, res, query }) => {
-  const searchQuery = query.query
-  const type = query.type
+  let searchQuery = query.query
+  let type = query.type
+  const oldQuery = query.q
+
+  // fix for legacy query parameters
+  if (oldQuery) {
+    searchQuery = oldQuery
+    type = 'web'
+    if (res) {
+      res.writeHead(301, { Location: `/search?query=${searchQuery}&type=${type}` })
+      return res.end()
+    } else {
+      return history.pushState('', '', `/search?query=${searchQuery}&type=${type}`)
+    }
+  }
+
   if (!searchQuery || !type) {
     if (res) {
       res.writeHead(301, { Location: '/' })


### PR DESCRIPTION
## Description
Since we change our query parameters from q={searchValue} to query={searchValue}&type={searchType}
the old searches in browsers histories, doesn't work anymore.
With this fix, if a search has just a q param, it will be redirect to our current query search

#### Impacted Areas in Application
search page
In particular from old searches and Firefox extension v2


#### Steps to Test or Reproduce
Try to search with /search?q={searchValue}
you should end up in /search?query={searchValue}&type=web and being able to see results

------------------------------------------------
## PR Checklist:

- [ ] My code follows the style guidelines of this project and I have double check my own code
- [ ] I have made corresponding changes to the documentation, if any
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run test` and be sure all test pass
- [ ] I have run `npm run build:dev` and be sure no error blovk the build
- [ ] I have test locally that everything run as expected
- [ ] I have properly fill in the PR template
- [ ] I have ask for reviews
