### PR TITLE
fix: add redirect from old why water to new one

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,4 +4,14 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const withPlugins = require('next-compose-plugins')
 const nextTranslate = require('next-translate')
 
-module.exports = withPlugins([[withBundleAnalyzer], nextTranslate])
+module.exports = withPlugins([[withBundleAnalyzer], nextTranslate], {
+  async redirects() {
+    return [
+      {
+        source: '/why-water.html',
+        destination: '/why-water',
+        permanent: true,
+      },
+    ]
+  },
+})


### PR DESCRIPTION
## Description
Old why water page was reachable under why-water.html
If people has this search saved in browser history will now see a 404 page.
We now redirect that search to /why-water nextjs page. 
We do that at server level

#### Impacted Areas in Application
why water page


#### Steps to Test or Reproduce
go to /why-water.html and should see the current why-water page instead of 404 error

------------------------------------------------
## PR Checklist:

- [ ] My code follows the style guidelines of this project and I have double check my own code
- [ ] I have made corresponding changes to the documentation, if any
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run test` and be sure all test pass
- [ ] I have run `npm run build:dev` and be sure no error blovk the build
- [ ] I have test locally that everything run as expected
- [ ] I have properly fill in the PR template
- [ ] I have ask for reviews
