### PR TITLE
fix: add title, location and proper url to ga pageview

### DIFF
--- a/helpers/_gtag.tsx
+++ b/helpers/_gtag.tsx
@@ -1,8 +1,10 @@
 export const GA_TRACKING_ID = 'UA-62300852-1' // This is your GA Tracking ID
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url) => {
+export const pageview = (title, location, url) => {
   window.gtag('config', GA_TRACKING_ID, {
+    page_title: title,
+    page_location: location,
     page_path: url,
   })
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,7 +16,7 @@ import { CookieMap } from '../helpers/_cookies'
 Router.events.on('routeChangeStart', () => NProgress.start())
 Router.events.on('routeChangeComplete', (url) => {
   if (process.env.IS_PRODUCTION) {
-    gtag.pageview(url)
+    gtag.pageview(document.title, location.href, url)
   }
   NProgress.done()
 })

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -309,7 +309,7 @@ function SearchPage({
   }
 
   return (
-    <Layout fluid pageTitle={query + t('search:pageTitle')} pageDescription={t('search:pageDescription')}>
+    <Layout fluid pageTitle={`${query} ` + t('search:pageTitle')} pageDescription={t('search:pageDescription')}>
       <section className='wrapper'>
         <div className='tabsWrapper'>
           <TabsMenu tabItems={TAB_MENU} activeTabId={activeTab.id} setActiveTab={handleSwitchTab} query={query} />


### PR DESCRIPTION
## Description
add title and location to google analytics pageView

#### Impacted Areas in Application
Each page loaded on Analytics

#### Steps to Test or Reproduce
On document.tsx and app.tsx, uncomment env.production and try to load a page. 
You shoudl see an event send to google analytics with page title, location and url
You should also see it on Analytics.

------------------------------------------------
## PR Checklist:

- [ ] My code follows the style guidelines of this project and I have double check my own code
- [ ] I have made corresponding changes to the documentation, if any
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run test` and be sure all test pass
- [ ] I have run `npm run build:dev` and be sure no error blovk the build
- [ ] I have test locally that everything run as expected
- [ ] I have properly fill in the PR template
- [ ] I have ask for reviews
